### PR TITLE
Update the Platform enum to include all supported platforms

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -26,7 +26,9 @@ type Ownership @entity {
 }
 
 enum Platform {
-  NiftyGateway,
-  Rarible,
+  KnowOrigin
+  NiftyGateway
+  OurZora
+  Rarible
   SuperRare
 }


### PR DESCRIPTION
I noticed the enum for `Platform` needed to be updated; this PR updates
the GraphQL schema to be inline with the platforms that are supported

